### PR TITLE
Bump @liqnft/candy-shop from 0.5.27 to 0.5.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@babel/core": "^7.0.0",
     "@babel/runtime": "7.x",
     "@civic/solana-gateway-react": "^0.4.12",
-    "@liqnft/candy-shop": "0.5.27",
+    "@liqnft/candy-shop": "0.5.28",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.60",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2157,12 +2157,12 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-6.10.0.tgz"
   integrity sha512-lLseUPEhSFUXYTKj6q7s2O3s2vW2ebgA11vMAlKodXGf5AFw4zUoEbTz9CoFOC9jS6xY4Qr8BmRnxP/odT4Uuw==
 
-"@liqnft/candy-shop-sdk@0.5.55":
-  version "0.5.55"
-  resolved "https://registry.yarnpkg.com/@liqnft/candy-shop-sdk/-/candy-shop-sdk-0.5.55.tgz#3d268d0915394ea8a6400791a66912a740bd211d"
-  integrity sha512-OHTBdMEzPG4WFmrI+ewGixyfKpWx+V13K9YzuJi8SW3v7gbKepwRvNa0KMVH9teVQZbJTexg5Qg63ukWGHlWAg==
+"@liqnft/candy-shop-sdk@0.5.56":
+  version "0.5.56"
+  resolved "https://registry.yarnpkg.com/@liqnft/candy-shop-sdk/-/candy-shop-sdk-0.5.56.tgz#812615dbdb627504f301d7da438a028a8dfa7823"
+  integrity sha512-Ds4DnAxOHS4OyalycmxX4ht/htnZAI6R1fp7bZFqyfPt3DFnq4Al8za4qHL51+H4AD+wJR8fl2F93pQ2lv5msw==
   dependencies:
-    "@liqnft/candy-shop-types" "0.2.55"
+    "@liqnft/candy-shop-types" "0.2.56"
     "@opensea/seaport-js" "^1.0.8"
     "@project-serum/anchor" "^0.23.0"
     "@solana/spl-token" "^0.2.0"
@@ -2175,19 +2175,19 @@
     idb "^7.0.1"
     qs "^6.10.3"
 
-"@liqnft/candy-shop-types@0.2.55":
-  version "0.2.55"
-  resolved "https://registry.yarnpkg.com/@liqnft/candy-shop-types/-/candy-shop-types-0.2.55.tgz#feff2ece90162beecfd194acc8130700179f0fdc"
-  integrity sha512-bnAFBhr314T1JgG7ZRdO3WxQxhDKaPyEiILLNpH8ES5JRsrbdJRgXmDAH9Poe2l8o3ej1VLoC9nRktcFbA2NUQ==
+"@liqnft/candy-shop-types@0.2.56":
+  version "0.2.56"
+  resolved "https://registry.yarnpkg.com/@liqnft/candy-shop-types/-/candy-shop-types-0.2.56.tgz#8f5e0a1a9881a2026fd25b676b0a31228261355b"
+  integrity sha512-JMX3F1LwWxM1thlK+pVjBg9zTskqQ69aVaMv5kSlulXT6xXl/okRUm4st36+uMUrZvyjytS8URdglT3VSFXTfA==
 
-"@liqnft/candy-shop@0.5.27":
-  version "0.5.27"
-  resolved "https://registry.yarnpkg.com/@liqnft/candy-shop/-/candy-shop-0.5.27.tgz#87ddf1630f0b46fb80d523234e1fc2cfcf681089"
-  integrity sha512-4odfL7Y1cs9+doO01YrIfW2z7ZhTYD+Q1zJdRAMSnH98si3e9/SN0ZIPztqLzxvT89TWST5P2hI0Hre/adBMPg==
+"@liqnft/candy-shop@0.5.28":
+  version "0.5.28"
+  resolved "https://registry.yarnpkg.com/@liqnft/candy-shop/-/candy-shop-0.5.28.tgz#0a10f991d13e36d5dafa1a8d15bf97520ce8d056"
+  integrity sha512-xf9Pl0M3fXtCF3gBq4q9WlocJSAhEolpswKhZ7uECf95AlKyEpKW033tccI/eaVulmScZ4peSLI8JRSUQaLZfA==
   dependencies:
     "@google/model-viewer" "1.8.0"
-    "@liqnft/candy-shop-sdk" "0.5.55"
-    "@liqnft/candy-shop-types" "0.2.55"
+    "@liqnft/candy-shop-sdk" "0.5.56"
+    "@liqnft/candy-shop-types" "0.2.56"
     "@project-serum/anchor" "^0.23.0"
     "@solana/spl-token" "^0.2.0"
     "@solana/wallet-adapter-react" "^0.15.0"


### PR DESCRIPTION
Bumps @liqnft/candy-shop from 0.5.27 to 0.5.28.

---
updated-dependencies:
- dependency-name: "@liqnft/candy-shop" dependency-type: direct:production update-type: version-update:semver-patch ...

Signed-off-by: dependabot[bot] <support@github.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Please mark relevant issues as closed/resolved here.

Please include a screenshot of relevant change if helpful.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Developer Tools
- [ ] Cypress
- [ ] CI
