### PR TITLE
Bump @liqnft/candy-shop from 0.5.32 to 0.5.33

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@babel/core": "^7.0.0",
     "@babel/runtime": "7.x",
     "@civic/solana-gateway-react": "^0.4.12",
-    "@liqnft/candy-shop": "0.5.32",
+    "@liqnft/candy-shop": "0.5.33",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.60",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2157,12 +2157,12 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-6.10.0.tgz"
   integrity sha512-lLseUPEhSFUXYTKj6q7s2O3s2vW2ebgA11vMAlKodXGf5AFw4zUoEbTz9CoFOC9jS6xY4Qr8BmRnxP/odT4Uuw==
 
-"@liqnft/candy-shop-sdk@0.5.60":
-  version "0.5.60"
-  resolved "https://registry.yarnpkg.com/@liqnft/candy-shop-sdk/-/candy-shop-sdk-0.5.60.tgz#1cd7bda7795c6bdd6f59b134e86bae00db994fff"
-  integrity sha512-+/XHZIyy5RveP4gBGSCn7Q9WiLm8WQ3oCSfOhMovZZ9L/DKmLxp073Ss0cdXA5Q8wJ3+a6n/kG9e9CYriEf6OQ==
+"@liqnft/candy-shop-sdk@0.5.61":
+  version "0.5.61"
+  resolved "https://registry.yarnpkg.com/@liqnft/candy-shop-sdk/-/candy-shop-sdk-0.5.61.tgz#dbe7bf5ed31b9ffcbada44df9b81ae63e6e8c59c"
+  integrity sha512-6Azfw1yofSXHv9mKFGDkqkrfY/NmITPNCoaQ1ojpKq/FV2O2pXQTWi7aURpq1W7nhqLtxfkAHcNy1VuNm6wW6A==
   dependencies:
-    "@liqnft/candy-shop-types" "0.2.60"
+    "@liqnft/candy-shop-types" "0.2.61"
     "@opensea/seaport-js" "^1.0.8"
     "@project-serum/anchor" "^0.23.0"
     "@solana/spl-token" "^0.2.0"
@@ -2175,19 +2175,19 @@
     idb "^7.0.1"
     qs "^6.10.3"
 
-"@liqnft/candy-shop-types@0.2.60":
-  version "0.2.60"
-  resolved "https://registry.yarnpkg.com/@liqnft/candy-shop-types/-/candy-shop-types-0.2.60.tgz#9e061fb3fdd0fcb9802c34b4a5399c66d85faabc"
-  integrity sha512-8tp4m+vYtzf6FWC8++qkicp4q8h17nq2AYFzl1VbiBDz69N/+HWQiEpr37NR9n8hMVoe9uxS7GoSGKt+daKhag==
+"@liqnft/candy-shop-types@0.2.61":
+  version "0.2.61"
+  resolved "https://registry.yarnpkg.com/@liqnft/candy-shop-types/-/candy-shop-types-0.2.61.tgz#77c2d0124f4623c52c0c879183c666880cc10246"
+  integrity sha512-rczR7fcVP7iatnxTn5UhgMiR6FjcrQ4h2GlCWnDSUwQBtC7LzyGRFBvB5zgp1FDv1o2mf3aKS3g4oOZPEvtAQg==
 
-"@liqnft/candy-shop@0.5.32":
-  version "0.5.32"
-  resolved "https://registry.yarnpkg.com/@liqnft/candy-shop/-/candy-shop-0.5.32.tgz#61e66b24b6a082fbf0f7e68997ef760b3f12bcde"
-  integrity sha512-Qezy0QXkkEF0t4GOG7QtlBmNuXyqPtB+G1cECo+FFM17XpW+jus5xMu3I9w7uAg12u4+Bq4ylInHia0ZjfWOVg==
+"@liqnft/candy-shop@0.5.33":
+  version "0.5.33"
+  resolved "https://registry.yarnpkg.com/@liqnft/candy-shop/-/candy-shop-0.5.33.tgz#6a585e05f1ee497d9791666242754d0d9dc87180"
+  integrity sha512-PmfhQuk6+o9qG3H98ta5gCPUz6ZkgtaBRD8NIDPqq4T4LOvt9wZ3QyMmfDbTLhWboIl+ZZG3OusgN1GLrHQ6cw==
   dependencies:
     "@google/model-viewer" "1.8.0"
-    "@liqnft/candy-shop-sdk" "0.5.60"
-    "@liqnft/candy-shop-types" "0.2.60"
+    "@liqnft/candy-shop-sdk" "0.5.61"
+    "@liqnft/candy-shop-types" "0.2.61"
     "@project-serum/anchor" "^0.23.0"
     "@solana/spl-token" "^0.2.0"
     "@solana/wallet-adapter-react" "^0.15.0"


### PR DESCRIPTION
Bumps @liqnft/candy-shop from 0.5.32 to 0.5.33.

---
updated-dependencies:
- dependency-name: "@liqnft/candy-shop" dependency-type: direct:production update-type: version-update:semver-patch ...

Signed-off-by: dependabot[bot] <support@github.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Please mark relevant issues as closed/resolved here.

Please include a screenshot of relevant change if helpful.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Developer Tools
- [ ] Cypress
- [ ] CI
