### PR TITLE
Bump @liqnft/candy-shop from 0.5.33 to 0.5.41

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@babel/core": "^7.0.0",
     "@babel/runtime": "7.x",
     "@civic/solana-gateway-react": "^0.4.12",
-    "@liqnft/candy-shop": "0.5.33",
+    "@liqnft/candy-shop": "0.5.41",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.60",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2157,12 +2157,12 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-6.10.0.tgz"
   integrity sha512-lLseUPEhSFUXYTKj6q7s2O3s2vW2ebgA11vMAlKodXGf5AFw4zUoEbTz9CoFOC9jS6xY4Qr8BmRnxP/odT4Uuw==
 
-"@liqnft/candy-shop-sdk@0.5.61":
-  version "0.5.61"
-  resolved "https://registry.yarnpkg.com/@liqnft/candy-shop-sdk/-/candy-shop-sdk-0.5.61.tgz#dbe7bf5ed31b9ffcbada44df9b81ae63e6e8c59c"
-  integrity sha512-6Azfw1yofSXHv9mKFGDkqkrfY/NmITPNCoaQ1ojpKq/FV2O2pXQTWi7aURpq1W7nhqLtxfkAHcNy1VuNm6wW6A==
+"@liqnft/candy-shop-sdk@0.5.77":
+  version "0.5.77"
+  resolved "https://registry.yarnpkg.com/@liqnft/candy-shop-sdk/-/candy-shop-sdk-0.5.77.tgz#16f98a118201087d3a4f57b3f672cdb6789360e5"
+  integrity sha512-cdd+8g6DN+v0mYRO4okerlLGrFwL0aX3ePTUt0S2mrmcMYv5yIAbkT3lZDWN5470Cb4ND5G5yGY868OcV6TYyA==
   dependencies:
-    "@liqnft/candy-shop-types" "0.2.61"
+    "@liqnft/candy-shop-types" "0.2.77"
     "@opensea/seaport-js" "^1.0.8"
     "@project-serum/anchor" "^0.23.0"
     "@solana/spl-token" "^0.2.0"
@@ -2170,30 +2170,30 @@
     "@solana/web3.js" "^1.47.3"
     axios "^0.26.1"
     crc-32 "^1.2.2"
-    decimal.js "^10.4.1"
     ethers "^5.7.1"
     idb "^7.0.1"
     qs "^6.10.3"
 
-"@liqnft/candy-shop-types@0.2.61":
-  version "0.2.61"
-  resolved "https://registry.yarnpkg.com/@liqnft/candy-shop-types/-/candy-shop-types-0.2.61.tgz#77c2d0124f4623c52c0c879183c666880cc10246"
-  integrity sha512-rczR7fcVP7iatnxTn5UhgMiR6FjcrQ4h2GlCWnDSUwQBtC7LzyGRFBvB5zgp1FDv1o2mf3aKS3g4oOZPEvtAQg==
+"@liqnft/candy-shop-types@0.2.77":
+  version "0.2.77"
+  resolved "https://registry.yarnpkg.com/@liqnft/candy-shop-types/-/candy-shop-types-0.2.77.tgz#b57c3f5e063d57a12c98c31031380521e1656bb1"
+  integrity sha512-SvGqpufbyBuKsq3XT5EPMHxCJV4I7BLnW4lBppUrXG/8LJ/L1+prhmiVnTFH5qvkOMZ03sapGVGnYfgSqw1CSg==
 
-"@liqnft/candy-shop@0.5.33":
-  version "0.5.33"
-  resolved "https://registry.yarnpkg.com/@liqnft/candy-shop/-/candy-shop-0.5.33.tgz#6a585e05f1ee497d9791666242754d0d9dc87180"
-  integrity sha512-PmfhQuk6+o9qG3H98ta5gCPUz6ZkgtaBRD8NIDPqq4T4LOvt9wZ3QyMmfDbTLhWboIl+ZZG3OusgN1GLrHQ6cw==
+"@liqnft/candy-shop@0.5.41":
+  version "0.5.41"
+  resolved "https://registry.yarnpkg.com/@liqnft/candy-shop/-/candy-shop-0.5.41.tgz#e12e131f73a79ae3ae67dd18ffa5a8b1d0040f24"
+  integrity sha512-ezSoqEUBSIf9JaP7q86/HSyvkOoxI/0yW4X7aWAmydsr4TjDSJIRV99m3WcBZ7Y3nPX5SaqA3jU/DqySPQKe4Q==
   dependencies:
     "@google/model-viewer" "1.8.0"
-    "@liqnft/candy-shop-sdk" "0.5.61"
-    "@liqnft/candy-shop-types" "0.2.61"
+    "@liqnft/candy-shop-sdk" "0.5.77"
+    "@liqnft/candy-shop-types" "0.2.77"
     "@project-serum/anchor" "^0.23.0"
     "@solana/spl-token" "^0.2.0"
     "@solana/wallet-adapter-react" "^0.15.0"
     "@solana/wallet-adapter-wallets" "^0.11.0"
     "@stripe/react-stripe-js" "^1.8.1"
     "@stripe/stripe-js" "^1.31.0"
+    "@wert-io/widget-initializer" "^2.0.3"
     axios "^0.26.1"
     crc-32 "^1.2.2"
     dayjs "^1.11.1"
@@ -3774,6 +3774,11 @@
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
+
+"@wert-io/widget-initializer@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@wert-io/widget-initializer/-/widget-initializer-2.0.3.tgz#6d885b32569cd150f0f466f1340cb4eb8c2d6742"
+  integrity sha512-y9jR388c6EvcAKlw2g3VgxCQAlfKvgowqlzlXtJt/sQBmkLHReH8R5m1JNFqE2g5fXCapQXUof/OB1znJOVXOw==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -5921,11 +5926,6 @@ decimal.js@^10.2.1:
   version "10.3.1"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.3.1.tgz"
   integrity sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==
-
-decimal.js@^10.4.1:
-  version "10.4.2"
-  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.2.tgz#0341651d1d997d86065a2ce3a441fbd0d8e8b98e"
-  integrity sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA==
 
 decode-uri-component@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Bumps @liqnft/candy-shop from 0.5.33 to 0.5.41.

---
updated-dependencies:
- dependency-name: "@liqnft/candy-shop" dependency-type: direct:production update-type: version-update:semver-patch ...

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Please mark relevant issues as closed/resolved here.

Please include a screenshot of relevant change if helpful.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Developer Tools
- [ ] Cypress
- [ ] CI
